### PR TITLE
メッセージ送信機能の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ gem 'pry-rails'
 gem 'carrierwave'
 
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -263,6 +267,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,13 @@
 $(function(){
   $('.new_message').on('submit', function(e){
     e.preventDefault()
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
     })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -57,4 +57,5 @@ $(function(){
       $('.MessageList').append(html);
       $('form')[0].reset();
       $('.MessageList').animate({ scrollTop: $('.MessageList')[0].scrollHeight});
+      $('.SubmitBtn').prop('disabled', false);
     })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,4 @@
+$(function(){
+  $('.new_message').on('submit', function(e){
+    e.preventDefault()
+    })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -59,3 +59,8 @@ $(function(){
       $('.MessageList').animate({ scrollTop: $('.MessageList')[0].scrollHeight});
       $('.SubmitBtn').prop('disabled', false);
     })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,45 @@
 $(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html =
+        `<div class="MessageBox">
+          <div class="MessageBox__MessageInfo">
+            <div class="MessageBox__MessageInfo__userName">
+              ${message.user_name}
+            </div>
+            <div class="MessageBox__MessageInfo__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="MessageBox__Message">
+            <p class="MessageBox__Message__content">
+              ${message.content}
+            </p>
+            <img class="Message__image" src="${message.image}">
+          </div>
+        </div>`
+      return html;
+    } else {
+      let html =
+      `<div class="MessageBox">
+        <div class="MessageBox__MessageInfo">
+          <div class="MessageBox__MessageInfo__userName">
+            ${message.user_name}
+          </div>
+          <div class="MessageBox__MessageInfo__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="MessageBox__Message">
+          <p class="MessageBox__Message__content">
+            ${message.content}
+          </p>
+        </div>
+      </div>`
+      return html;
+    };
+  }
+  
   $('.new_message').on('submit', function(e){
     e.preventDefault()
     let formData = new FormData(this);
@@ -10,4 +51,7 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
     })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -54,4 +54,7 @@ $(function(){
     })
     .done(function(data){
       let html = buildHTML(data);
+      $('.MessageList').append(html);
+      $('form')[0].reset();
+      $('.MessageList').animate({ scrollTop: $('.MessageList')[0].scrollHeight});
     })

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module ChatSpace
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
メッセージ送信機能の非同期化した。以下の手順で実装した。

1.JavaScriptとjQueryを導入
2.フォームが送信されたら、イベントが発火するよう設定
3.Ajaxを使用して、messages#createが動くように設定
4.messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分岐
5.jbuilderを使用して、作成したメッセージをJSON形式で返す
6.返ってきたJSONをdoneメソッドで受取り、HTMLを作成
7.作成したHTMLをメッセージ画面の一番下に追加
8.メッセージを送信したとき、メッセージ画面を最下部にスクロール
9.連続で送信ボタンを押せるように設定
10.非同期に失敗した場合の処理を設定

# Why
非同期前のメッセージの送信機能は、メッセージを送信するたびに送信画面にリダイレクトし、ビューが毎回再描画されてしまう仕様となっていた。そこで、よりクライアントにとって使いやすいメッセージ送信機能にするため、非同期化した。

# gifの動画キャプチャ
https://gyazo.com/22f489b7c472de3c4d3ee1d16358b049